### PR TITLE
harden retries, sanity-ize model choice by tier, enable pred market tools

### DIFF
--- a/.github/workflows/run_bot_on_metaculus_cup.yaml
+++ b/.github/workflows/run_bot_on_metaculus_cup.yaml
@@ -95,3 +95,7 @@ jobs:
           # p=0.113), so excluded.
           PROBABILISTIC_TOOLS_ENABLED: 'true'
           PROBABILISTIC_TOOLS_TYPES: 'binary,multiple_choice'
+          # Prediction-market snapshot provider: Polymarket + Kalshi + Manifold.
+          # is_benchmarking=False in the prod path (this workflow), so the
+          # provider's own benchmarking guard doesn't suppress it here.
+          PREDICTION_MARKETS_ENABLED: 'true'

--- a/.github/workflows/run_bot_on_minibench.yaml
+++ b/.github/workflows/run_bot_on_minibench.yaml
@@ -106,3 +106,7 @@ jobs:
           # p=0.113), so excluded.
           PROBABILISTIC_TOOLS_ENABLED: 'true'
           PROBABILISTIC_TOOLS_TYPES: 'binary,multiple_choice'
+          # Prediction-market snapshot provider: Polymarket + Kalshi + Manifold.
+          # is_benchmarking=False in the prod path (this workflow), so the
+          # provider's own benchmarking guard doesn't suppress it here.
+          PREDICTION_MARKETS_ENABLED: 'true'

--- a/.github/workflows/run_bot_on_tournament.yaml
+++ b/.github/workflows/run_bot_on_tournament.yaml
@@ -107,3 +107,8 @@ jobs:
           # p=0.113), so excluded.
           PROBABILISTIC_TOOLS_ENABLED: 'true'
           PROBABILISTIC_TOOLS_TYPES: 'binary,multiple_choice'
+          # Prediction-market snapshot provider: queries Polymarket, Kalshi,
+          # Manifold concurrently and aggregates into research blurb. Hard-
+          # disabled under is_benchmarking=True to prevent backtest leakage
+          # (the prod path is_benchmarking=False, so this fires here).
+          PREDICTION_MARKETS_ENABLED: 'true'

--- a/.github/workflows/test_bot.yaml
+++ b/.github/workflows/test_bot.yaml
@@ -93,3 +93,7 @@ jobs:
           # Second-pass gap-fill: analyzer identifies gaps in first-pass research,
           # parallel grounded Gemini searches resolve each. Fails soft.
           GAP_FILL_ENABLED: 'true'
+          # Prediction-market snapshot provider: Polymarket + Kalshi + Manifold.
+          # Manual workflow_dispatch runs use this for end-to-end testing in prod
+          # mode (is_benchmarking=False).
+          PREDICTION_MARKETS_ENABLED: 'true'

--- a/metaculus_bot/constants.py
+++ b/metaculus_bot/constants.py
@@ -231,11 +231,30 @@ NATIVE_SEARCH_MAX_TOKENS: int = 16_000
 NATIVE_SEARCH_TIMEOUT: int = (
     360  # 2026-05-17: raised 240→360 alongside gpt-5.5 medium-effort migration; see comparison_v3.md
 )
+# Wall-clock backstop for the native-search provider. NATIVE_SEARCH_TIMEOUT
+# above is the litellm per-HTTP-request timeout; it resets across retries
+# (allowed_tries default 3 ⇒ worst case ~18 min) and was observed defeated
+# entirely on 2026-05-20 by an OpenRouter response that dripped ~700 lines of
+# whitespace keep-alive bytes over 8m37s before closing with malformed JSON.
+# asyncio.wait_for around llm.invoke gives us a hard wall-clock cap regardless
+# of what the underlying HTTP layer does. Slight headroom over the request
+# timeout so the cleaner per-request error fires first when possible.
+NATIVE_SEARCH_WALL_TIMEOUT: int = 420
 # Reasoning effort and verbosity for the OpenAI native-search call.
 # Override via env vars NATIVE_SEARCH_REASONING_EFFORT / NATIVE_SEARCH_VERBOSITY.
 # Empty string disables passing the kwarg.
 NATIVE_SEARCH_REASONING_EFFORT_ENV: str = "NATIVE_SEARCH_REASONING_EFFORT"
-NATIVE_SEARCH_REASONING_EFFORT_DEFAULT: str = "medium"
+# 2026-05-20: dropped medium→low after the OpenRouter whitespace-stream incident
+# that consumed 8m37s on a single call. v3 bench (comparison_v3.md) measured
+# gpt-5.5 effort=low at ~50s vs effort=medium at ~230s, so low gives ~4.5×
+# faster wall-clock and far more headroom under NATIVE_SEARCH_WALL_TIMEOUT (420s)
+# / NATIVE_SEARCH_TIMEOUT (360s). Caveat: v3 only sanity-checked low for latency,
+# not graded quality (mini at default scored 15/25, gpt-5.5 medium 23/25, low
+# unknown). Override via NATIVE_SEARCH_REASONING_EFFORT env if a workflow needs
+# medium quality back. Note: this default applies ONLY to the native-search
+# provider — DISAGREEMENT_ANALYZER_LLM stays at medium (llm_configs.py:182),
+# all forecasters stay at high.
+NATIVE_SEARCH_REASONING_EFFORT_DEFAULT: str = "low"
 NATIVE_SEARCH_VERBOSITY_ENV: str = "NATIVE_SEARCH_VERBOSITY"
 NATIVE_SEARCH_VERBOSITY_DEFAULT: str = "low"
 # Native search web options (passed to OpenRouter plugins)
@@ -279,7 +298,14 @@ GEMINI_SEARCH_TIMEOUT: int = 180
 # Gemini search. Fails soft — forecast proceeds with first-pass research alone
 # if any stage errors out.
 GAP_FILL_ENABLED_ENV: str = "GAP_FILL_ENABLED"
-GAP_FILL_ANALYZER_MODEL: str = "gemini-3-flash-preview"
+# 2026-05-20: migrated analyzer from gemini-3-flash-preview (google-genai SDK
+# direct) to gpt-5.5 effort=low via OpenRouter. The analyzer is non-grounded —
+# it reads the first-pass research and emits a JSON list of factual gaps —
+# so it doesn't need Google as a search index, and OpenAI-stack consistency
+# matches the rest of the auxiliary tier (native_search, disagreement_analyzer
+# also at gpt-5.5 low). Grounded search resolution still uses google-genai
+# directly via gemini_search_provider — that path needs the search index.
+GAP_FILL_ANALYZER_MODEL: str = "openrouter/openai/gpt-5.5"
 GAP_FILL_MAX_GAPS: int = 5
 # Analyzer call is non-grounded (no Google Search) and should return quickly.
 # Use a tight timeout to prevent a single hung analyzer request from holding a

--- a/metaculus_bot/constants.py
+++ b/metaculus_bot/constants.py
@@ -311,6 +311,13 @@ GAP_FILL_MAX_GAPS: int = 5
 # Use a tight timeout to prevent a single hung analyzer request from holding a
 # research concurrency slot for the full grounded-search budget.
 GAP_FILL_ANALYZER_TIMEOUT: int = 120
+# Wall-clock backstop for the analyzer call. Slight headroom over
+# GAP_FILL_ANALYZER_TIMEOUT so the cleaner per-request error from litellm fires
+# first when possible (auth failure, model-not-found, etc.) — same pattern as
+# NATIVE_SEARCH_WALL_TIMEOUT vs NATIVE_SEARCH_TIMEOUT (60s headroom). Without
+# this, asyncio.wait_for and the litellm request timeout fire at the exact
+# same second and we lose the descriptive error message.
+GAP_FILL_ANALYZER_WALL_TIMEOUT: int = 135
 # Skip gap-fill when the first-pass research blob has less than this many
 # non-whitespace characters — likely indicates all providers soft-failed and
 # gap-fill would just hallucinate gaps or burn quota.

--- a/metaculus_bot/llm_configs.py
+++ b/metaculus_bot/llm_configs.py
@@ -121,14 +121,13 @@ PARSER_LLM: GeneralLlm = build_llm_with_openrouter_fallback(
     reasoning={"effort": "low"},
     **DETERMINISTIC_MODEL_CONFIG,
 )
-# Researcher is only used by the base bot when internal research is invoked.
-# Our implementation uses providers, but we still set it explicitly to avoid silent defaults.
-# Migrated 2026-05-17 same rationale as SUMMARIZER_LLM above.
-RESEARCHER_LLM = build_llm_with_openrouter_fallback(
-    model="openrouter/openai/gpt-5.4-mini",
-    reasoning={"effort": "low"},
-    **DETERMINISTIC_MODEL_CONFIG,
-)
+# Researcher slot in the forecasting-tools LLM config dict. Effectively dead
+# code in our pipeline — we use research providers (AskNews/Gemini/native_search)
+# rather than the framework's researcher path — but the slot must be populated
+# to avoid silent framework defaults. Aliasing to SUMMARIZER_LLM rather than
+# constructing a duplicate config: same model, same effort, same job tier, no
+# reason to maintain two parallel definitions.
+RESEARCHER_LLM = SUMMARIZER_LLM
 
 # Stacker meta-model for conditional stacking (invoked only on high-disagreement questions).
 #
@@ -172,13 +171,14 @@ PREDICTION_MARKET_KEYWORD_LLM_CONFIG: dict = {
 }
 
 
-# Medium-effort model for identifying the crux of model disagreement (feeds into targeted research).
-# Crux text becomes the targeted-search query, so quality drives downstream retrieval quality;
-# medium effort gives faster wall-clock for a structured 1-3 sentence extraction without
-# materially hurting quality, and matches the effort tier we settled on for native search.
-# Cost is ~$0.055/disagreement-Q × ~75 Qs/tournament = ~$4/tournament — negligible.
+# Tier-B auxiliary: read-and-synthesize work that needs taste but not deep
+# reasoning. Identifies the crux of forecaster disagreement; output text seeds
+# the targeted-search query downstream. Dropped 2026-05-20 from medium→low
+# effort alongside the broader tier-B consolidation (native_search also at low):
+# 1-3 sentence crux extraction is structure-following with light judgment, not
+# deep reasoning. Cost roughly halves (~$4 → ~$1.50/tournament).
 DISAGREEMENT_ANALYZER_LLM: GeneralLlm = build_llm_with_openrouter_fallback(
     "openrouter/openai/gpt-5.5",
-    reasoning={"effort": "medium"},
+    reasoning={"effort": "low"},
     **DETERMINISTIC_MODEL_CONFIG,
 )

--- a/metaculus_bot/research_providers.py
+++ b/metaculus_bot/research_providers.py
@@ -327,6 +327,12 @@ def build_native_search_llm(model_slug: str | None = None) -> GeneralLlm:
         top_p=NATIVE_SEARCH_TOP_P,
         max_tokens=NATIVE_SEARCH_MAX_TOKENS,
         timeout=NATIVE_SEARCH_TIMEOUT,
+        # allowed_tries=1: a malformed-whitespace response from OpenRouter (the
+        # 2026-05-20 incident) won't be cured by retrying the same call, and
+        # the wall-clock guard at the caller (asyncio.wait_for in _fetch) is
+        # bounding the budget. With allowed_tries=1 + wait_for(420s), worst
+        # case is ~7 min instead of timeout(360s) * default_tries(3) ~18 min.
+        allowed_tries=1,
         plugins=[{"id": "web", "max_results": NATIVE_SEARCH_MAX_RESULTS, "engine": "native"}],
         web_search_options={"search_context_size": NATIVE_SEARCH_CONTEXT_SIZE},
     )
@@ -355,6 +361,8 @@ def _native_search_provider(
     """Research provider using models with native web search capability via OpenRouter :online suffix."""
 
     async def _fetch(question: MetaculusQuestion) -> str:  # noqa: D401
+        from metaculus_bot.constants import NATIVE_SEARCH_WALL_TIMEOUT
+
         llm = build_native_search_llm(model_slug)
         prompt = web_research_prompt(
             question.question_text,
@@ -362,7 +370,11 @@ def _native_search_provider(
             citation_style="markdown",
         )
         logger.info(f"NativeSearch: Calling {llm.model} for research")
-        result = await llm.invoke(prompt)
+        # Wall-clock backstop: see NATIVE_SEARCH_WALL_TIMEOUT in constants.py
+        # for the 2026-05-20 incident that motivated this guard. Mirrors the
+        # AskNews (research_providers.py:89) and gemini gap-fill
+        # (targeted_research.py:182) wrappers.
+        result = await asyncio.wait_for(llm.invoke(prompt), timeout=NATIVE_SEARCH_WALL_TIMEOUT)
         logger.info(f"NativeSearch: Got {len(result)} chars from {llm.model}")
         return result
 

--- a/metaculus_bot/targeted_research.py
+++ b/metaculus_bot/targeted_research.py
@@ -14,17 +14,14 @@ import json
 import logging
 from typing import Any
 
-import httpx
 from forecasting_tools import GeneralLlm, MetaculusQuestion
-from google.genai import errors as genai_errors
-from google.genai import types as genai_types
 
 from metaculus_bot.constants import (
     GAP_FILL_ANALYZER_MODEL,
     GAP_FILL_ANALYZER_TIMEOUT,
     GAP_FILL_MAX_GAPS,
 )
-from metaculus_bot.gemini_search_provider import build_gemini_client, invoke_gemini_grounded
+from metaculus_bot.gemini_search_provider import invoke_gemini_grounded
 from metaculus_bot.prompts import (
     disagreement_crux_prompt,
     gap_fill_analyzer_prompt,
@@ -43,14 +40,15 @@ __all__ = [
 logger: logging.Logger = logging.getLogger(__name__)
 
 # Exceptions that trigger a soft-fail (return "") from run_gap_fill_pass.
-_GAP_FILL_SOFT_FAIL_EXCEPTIONS: tuple[type[BaseException], ...] = (
-    asyncio.TimeoutError,
-    ValueError,  # missing GOOGLE_API_KEY from build_gemini_client
-    genai_errors.APIError,  # covers ClientError + ServerError from the SDK
-    httpx.HTTPError,  # raw httpx network errors (SDK uses httpx underneath)
-    ConnectionError,
-    OSError,  # DNS / socket failures not wrapped by httpx
-)
+# Broad by design — the docstring policy is "Never raises. Returns '' on any
+# upstream failure" (gap-fill is an optional enrichment layer; a forecast with
+# only first-pass research is strictly better than no forecast at all). Listing
+# specific classes was tractable when both stages used google-genai; after the
+# 2026-05-20 analyzer migration to OpenRouter/litellm, the analyzer can raise
+# litellm.APIError, openai.AuthenticationError, anthropic.RateLimitError, etc.
+# Catching `Exception` matches the policy and keeps the catch in one place
+# (CancelledError still propagates because it inherits from BaseException).
+_GAP_FILL_SOFT_FAIL_EXCEPTIONS: tuple[type[BaseException], ...] = (Exception,)
 
 
 async def extract_disagreement_crux(
@@ -162,13 +160,26 @@ async def _run_analyzer(
     *,
     is_benchmarking: bool,
 ) -> list[dict[str, str]]:
-    """Call the analyzer Gemini model (no grounding) to identify gaps.
+    """Call the analyzer LLM (no grounding) to identify gaps.
 
-    Uses `response_mime_type="application/json"` so the model returns valid JSON
-    directly rather than prose-wrapped JSON, which makes `_parse_gap_list` more
-    reliable and documents the "no grounding" contract explicitly.
+    Migrated 2026-05-20 from gemini-3-flash-preview (google-genai direct) to
+    gpt-5.5 low-effort via OpenRouter (with donated-key fallback). The analyzer
+    is non-grounded so it doesn't need Google's search index; this gets us
+    OpenAI-stack consistency with native_search and the disagreement analyzer.
+
+    Without google-genai's response_mime_type=application/json, the prompt asks
+    for ```json fenced output and _parse_gap_list handles fence stripping +
+    balanced-brace fallback for trailing commentary.
     """
-    client = build_gemini_client()
+    from metaculus_bot.fallback_openrouter import build_llm_with_openrouter_fallback
+
+    llm = build_llm_with_openrouter_fallback(
+        model=GAP_FILL_ANALYZER_MODEL,
+        reasoning={"effort": "low"},
+        temperature=0.0,
+        timeout=GAP_FILL_ANALYZER_TIMEOUT,
+        allowed_tries=1,
+    )
     prompt = gap_fill_analyzer_prompt(
         question_text=question.question_text,
         resolution_criteria=getattr(question, "resolution_criteria", None),
@@ -177,13 +188,8 @@ async def _run_analyzer(
         is_benchmarking=is_benchmarking,
         max_gaps=GAP_FILL_MAX_GAPS,
     )
-    config = genai_types.GenerateContentConfig(response_mime_type="application/json")
     logger.info(f"GapFill: calling analyzer {GAP_FILL_ANALYZER_MODEL} for gap identification")
-    response = await asyncio.wait_for(
-        client.aio.models.generate_content(model=GAP_FILL_ANALYZER_MODEL, contents=prompt, config=config),
-        timeout=GAP_FILL_ANALYZER_TIMEOUT,
-    )
-    raw_text: str = getattr(response, "text", "") or ""
+    raw_text = await asyncio.wait_for(llm.invoke(prompt), timeout=GAP_FILL_ANALYZER_TIMEOUT)
     gaps = _parse_gap_list(raw_text, max_gaps=GAP_FILL_MAX_GAPS)
     logger.info(f"GapFill: analyzer returned {len(gaps)} gap(s)")
     return gaps
@@ -218,8 +224,8 @@ async def run_gap_fill_pass(
     """Identify and resolve factual gaps in first-pass research.
 
     Two-stage flow:
-    1. Analyzer call (Gemini 3 Flash, no grounding) → JSON list of up to
-       ``GAP_FILL_MAX_GAPS`` gaps.
+    1. Analyzer call (gpt-5.5 effort=low via OpenRouter, no grounding) → JSON
+       list of up to ``GAP_FILL_MAX_GAPS`` gaps.
     2. Parallel grounded Gemini searches, one per gap, via ``asyncio.gather``.
 
     Never raises. Returns "" on any upstream failure (missing API key, timeout,

--- a/metaculus_bot/targeted_research.py
+++ b/metaculus_bot/targeted_research.py
@@ -19,7 +19,9 @@ from forecasting_tools import GeneralLlm, MetaculusQuestion
 from metaculus_bot.constants import (
     GAP_FILL_ANALYZER_MODEL,
     GAP_FILL_ANALYZER_TIMEOUT,
+    GAP_FILL_ANALYZER_WALL_TIMEOUT,
     GAP_FILL_MAX_GAPS,
+    NATIVE_SEARCH_WALL_TIMEOUT,
 )
 from metaculus_bot.gemini_search_provider import invoke_gemini_grounded
 from metaculus_bot.prompts import (
@@ -90,7 +92,12 @@ async def run_targeted_search(crux: str, question_text: str, *, is_benchmarking:
     llm = build_native_search_llm()
     prompt = targeted_search_prompt(crux, question_text, is_benchmarking=is_benchmarking)
     logger.info(f"Running targeted search via {llm.model} for crux: {crux[:100]}...")
-    result = await llm.invoke(prompt)
+    # Wall-clock backstop: shares NATIVE_SEARCH_WALL_TIMEOUT with the
+    # native_search research provider since both call the same LLM
+    # configuration via build_native_search_llm. The 2026-05-20 OpenRouter
+    # whitespace-drip incident defeated litellm's per-HTTP-request timeout;
+    # asyncio.wait_for is the hard cap regardless of upstream behavior.
+    result = await asyncio.wait_for(llm.invoke(prompt), timeout=NATIVE_SEARCH_WALL_TIMEOUT)
     logger.info(f"Targeted search complete: {len(result)} chars")
     return result
 
@@ -189,7 +196,10 @@ async def _run_analyzer(
         max_gaps=GAP_FILL_MAX_GAPS,
     )
     logger.info(f"GapFill: calling analyzer {GAP_FILL_ANALYZER_MODEL} for gap identification")
-    raw_text = await asyncio.wait_for(llm.invoke(prompt), timeout=GAP_FILL_ANALYZER_TIMEOUT)
+    # Wall-clock backstop has slight headroom over the litellm per-request
+    # timeout (135s vs 120s) so the cleaner per-request error fires first when
+    # possible, mirroring NATIVE_SEARCH_WALL_TIMEOUT vs NATIVE_SEARCH_TIMEOUT.
+    raw_text = await asyncio.wait_for(llm.invoke(prompt), timeout=GAP_FILL_ANALYZER_WALL_TIMEOUT)
     gaps = _parse_gap_list(raw_text, max_gaps=GAP_FILL_MAX_GAPS)
     logger.info(f"GapFill: analyzer returned {len(gaps)} gap(s)")
     return gaps

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -53,24 +53,28 @@ class TestMCClampBoundsUnchanged:
 
 
 class TestNativeSearchDefaults:
-    """Pin OpenAI native-search defaults to the W-A bench winner.
+    """Pin OpenAI native-search defaults.
 
-    These four constants together are the configuration that came out on top in
-    ``scratch/native_search_bench_2026-05-17/comparison_v3.md`` — gpt-5.5 with
-    medium reasoning effort + low verbosity, fitting under a 360s cap with
-    materially deeper research than the gpt-5.4-mini fallback. Don't change
-    these without rerunning the bench; rotating to a new model on a hunch
-    silently regresses research quality on every question.
+    Model + verbosity locked from ``scratch/native_search_bench_2026-05-17/comparison_v3.md``.
+    Reasoning effort dropped medium→low on 2026-05-20 after an OpenRouter
+    whitespace-stream incident consumed 8m37s on a single call; v3 bench
+    measured low at ~50s vs medium at ~230s, so low gives ~4.5× more headroom
+    under the wall-clock cap. Quality at low is not graded by the v3 bench
+    (sanity-check only) — rerun the bench with a graded `low` arm if you
+    want to revert.
     """
 
     def test_native_search_default_model_is_gpt_5_5(self):
         """Locks the default OpenRouter model to ``openai/gpt-5.5``."""
         assert NATIVE_SEARCH_DEFAULT_MODEL == "openai/gpt-5.5"
 
-    def test_native_search_reasoning_effort_default_is_medium(self):
-        """Medium effort is the bench winner — high burned budget without
-        improving rubric scores; low produced shallower research."""
-        assert NATIVE_SEARCH_REASONING_EFFORT_DEFAULT == "medium"
+    def test_native_search_reasoning_effort_default_is_low(self):
+        """Low effort gives ~4.5× faster wall-clock vs medium on the v3 bench
+        (~50s vs ~230s), keeping us well clear of NATIVE_SEARCH_WALL_TIMEOUT
+        (420s) after the 2026-05-20 OpenRouter whitespace-stream incident.
+        Override via NATIVE_SEARCH_REASONING_EFFORT env if a workflow needs
+        medium quality back."""
+        assert NATIVE_SEARCH_REASONING_EFFORT_DEFAULT == "low"
 
     def test_native_search_verbosity_default_is_low(self):
         """Low verbosity keeps the response tight without losing substance."""

--- a/tests/test_native_search_provider.py
+++ b/tests/test_native_search_provider.py
@@ -46,9 +46,15 @@ async def test_native_search_provider_constructs_correct_model_name(
     # `verbosity` is now top-level (canonical OpenRouter / litellm form);
     # `extra_body` is no longer used to smuggle it.
     assert captured_kwargs is not None
-    assert captured_kwargs.get("reasoning") == {"effort": "medium"}
+    # Default reasoning effort dropped medium→low on 2026-05-20; see
+    # NATIVE_SEARCH_REASONING_EFFORT_DEFAULT in constants.py for rationale.
+    assert captured_kwargs.get("reasoning") == {"effort": "low"}
     assert captured_kwargs.get("verbosity") == "low"
     assert "extra_body" not in captured_kwargs
+    # 2026-05-20: pinned to allowed_tries=1 for native_search; the wall-clock
+    # guard at the caller bounds the budget, retrying a malformed-whitespace
+    # response from OpenRouter doesn't help (and burns the budget).
+    assert captured_kwargs.get("allowed_tries") == 1
 
 
 @pytest.mark.asyncio
@@ -153,6 +159,41 @@ async def test_native_search_provider_prompt_includes_anti_hallucination_guidanc
     assert captured_prompt is not None
     assert "DO NOT hallucinate" in captured_prompt
     assert "only cite what you actually found" in captured_prompt
+
+
+@pytest.mark.asyncio
+async def test_native_search_provider_enforces_wall_clock_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A hung llm.invoke must be bounded by NATIVE_SEARCH_WALL_TIMEOUT.
+
+    Regression test for the 2026-05-20 incident: an OpenRouter response
+    dripped ~700 lines of whitespace over 8m37s before closing with malformed
+    JSON, defeating the per-HTTP-request timeout entirely. The asyncio.wait_for
+    wrapper in _native_search_provider._fetch is the wall-clock backstop;
+    this test locks it in so a future refactor can't silently remove it.
+    """
+    # _fetch reads NATIVE_SEARCH_WALL_TIMEOUT via a function-scoped import from
+    # constants, so we patch the constants module (not the research_providers
+    # module) for the override to take effect at call time.
+    monkeypatch.setattr("metaculus_bot.constants.NATIVE_SEARCH_WALL_TIMEOUT", 0.05)
+
+    class HangingLlm:
+        def __init__(self, **kwargs):  # type: ignore[no-untyped-def]
+            self.model = kwargs.get("model", "mock")
+
+        async def invoke(self, prompt: str) -> str:
+            # Sleep well past the 0.05s wall-clock cap; test passes only if
+            # asyncio.wait_for cancels this before it returns.
+            await asyncio.sleep(5)
+            return "should never reach here"
+
+    with patch("metaculus_bot.research_providers.GeneralLlm", HangingLlm):
+        from metaculus_bot.research_providers import native_search_provider
+
+        provider = native_search_provider()
+        with pytest.raises(asyncio.TimeoutError):
+            await provider(_make_q("Will X happen?"))
 
 
 class TestParallelProviderSelection:

--- a/tests/test_targeted_research.py
+++ b/tests/test_targeted_research.py
@@ -1,5 +1,6 @@
 """Unit tests for targeted_research module and its prompt functions."""
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -104,3 +105,31 @@ class TestRunTargetedSearch:
             await run_targeted_search("crux", "q", is_benchmarking=True)
 
         mock_prompt.assert_called_once_with("crux", "q", is_benchmarking=True)
+
+    @pytest.mark.asyncio
+    async def test_enforces_wall_clock_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A hung llm.invoke must be bounded by NATIVE_SEARCH_WALL_TIMEOUT.
+
+        run_targeted_search shares the build_native_search_llm config with the
+        native_search research provider, so the same OpenRouter whitespace-drip
+        pathology (2026-05-20 incident) can defeat the per-HTTP-request timeout
+        here too. The asyncio.wait_for wrapper is the wall-clock backstop;
+        this test locks it in so a future refactor can't silently remove it.
+        """
+        # Override the wall-clock cap to a short value via the constants module
+        # (run_targeted_search reads it at import time, but patching the
+        # already-imported reference in targeted_research is what takes effect).
+        monkeypatch.setattr("metaculus_bot.targeted_research.NATIVE_SEARCH_WALL_TIMEOUT", 0.05)
+
+        class HangingLlm:
+            model = "mock-native-search"
+
+            async def invoke(self, prompt: str) -> str:
+                # Sleep well past the 0.05s wall-clock cap; test passes only if
+                # asyncio.wait_for cancels this before it returns.
+                await asyncio.sleep(5)
+                return "should never reach here"
+
+        with patch("metaculus_bot.targeted_research.build_native_search_llm", return_value=HangingLlm()):
+            with pytest.raises(asyncio.TimeoutError):
+                await run_targeted_search("crux", "question text")


### PR DESCRIPTION
…ls, enable prediction markets

native_search root-cause fix (motivating bug):
- Add wall-clock backstop to _native_search_provider via asyncio.wait_for(420s). The litellm `timeout` kwarg is per-HTTP-request and resets on retry; it was also defeated entirely by an OpenRouter response that dripped ~700 lines of whitespace over 8m37s on 2026-05-20 before closing with malformed JSON.
- Pin allowed_tries=1: a malformed-whitespace response won't be cured by a retry, and the wall-clock guard already bounds the budget.
- Drop reasoning effort default medium→low; v3 bench measured ~50s vs ~230s, giving ~4.5x more headroom under the wall-clock cap. Override via NATIVE_SEARCH_REASONING_EFFORT env if a workflow needs medium back.

Auxiliary-tier consolidation (tier B reads-and-synthesizes, gpt-5.5 effort=low):
- Drop disagreement analyzer to gpt-5.5 effort=low (was medium). Crux extraction is structure-following with light judgment.
- Migrate gap-fill analyzer from gemini-3-flash-preview (google-genai direct) to gpt-5.5 effort=low via OpenRouter. Non-grounded analysis path that doesn't need Google as a search index; gets us OpenAI-stack consistency with native_search and disagreement_analyzer. Grounded gap resolution still uses google-genai (needs the search index).
- Broaden _GAP_FILL_SOFT_FAIL_EXCEPTIONS to (Exception,) — matches the docstring policy ("Never raises. Returns ''") and covers the new litellm/openai/anthropic exception classes. CancelledError still propagates via BaseException.
- Alias RESEARCHER_LLM = SUMMARIZER_LLM. The slot is dead code in our pipeline (we use providers, not the framework researcher path) but must be populated to avoid silent framework defaults.

Prediction markets enablement:
- Set PREDICTION_MARKETS_ENABLED=true in all 4 workflows (tournament, cup, minibench, test_bot). Provider was built, wired, and tested but the workflow env flag was never flipped — completing the missing last step of the 2026-05-12 plan in atlas_inspired_improvements.md §G. Hard-disabled under is_benchmarking=True so backtests stay leakage-free.

Tests:
- Add test_native_search_provider_enforces_wall_clock_timeout regression test (locks in the asyncio.wait_for guard the way AskNews and gemini gap-fill grounded search are locked in).
- Update test_native_search_default to assert effort=low and allowed_tries=1.
- Update test_constants TestNativeSearchDefaults to lock in low.
- Full suite: 2097 passed, 10 skipped, 0 failed.