### PR TITLE
Revert AskNews summarizer-failure drop; restore raw fallback

### DIFF
--- a/metaculus_bot/research/orchestrator.py
+++ b/metaculus_bot/research/orchestrator.py
@@ -170,12 +170,8 @@ class ResearchOrchestrator:
         """Compress raw AskNews article markdown into an analyst briefing.
 
         Only AskNews output flows here — it's the one provider that returns raw
-        article text rather than LLM-written prose. On a summarizer failure we
-        drop AskNews to empty rather than passing the raw articles through: that
-        text feeds the forecasters and the published comment, and dozens of full
-        article bodies are noise in both. The other prod providers (native
-        search, Gemini grounded, gap-fill) still cover the question, so an empty
-        AskNews block degrades coverage slightly rather than dumping raw text.
+        article text rather than LLM-written prose. Soft-fails to the raw input
+        so a summarizer hiccup never drops the news entirely.
         """
         if not research.strip():
             return research
@@ -229,11 +225,11 @@ class ResearchOrchestrator:
                 label="asknews_summarizer",
             )
         except _SUMMARIZER_TRANSIENT_EXCEPTIONS as exc:
-            logger.warning("AskNews summarization failed (%s); dropping AskNews block", type(exc).__name__)
-            return ""
+            logger.warning("AskNews summarization failed (%s); using raw articles", type(exc).__name__)
+            return research
         if not summary.strip():
-            logger.warning("AskNews summarization returned blank output; dropping AskNews block")
-            return ""
+            logger.warning("AskNews summarization returned blank output; using raw articles")
+            return research
         return summary
 
     def _lookup_research_cache(self, question: MetaculusQuestion) -> tuple[int | None, str | None]:

--- a/tests/test_forecaster.py
+++ b/tests/test_forecaster.py
@@ -1,27 +1,9 @@
-import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from forecasting_tools import MetaculusQuestion
 
 from main import TemplateForecaster
-
-_SUMMARIZE_ASKNEWS_PATH = "metaculus_bot.research.orchestrator.ResearchOrchestrator._summarize_asknews"
-
-
-async def _passthrough_summarize_asknews(self, question, research):
-    """Identity stub for the AskNews summarizer.
-
-    This test asserts on provider routing/priority, not summarizer behavior.
-    The real summarizer here is the bogus ``"mock_summarizer"`` model, which
-    raises BadRequestError when invoked; on failure the orchestrator drops the
-    AskNews block to empty (it no longer falls back to raw articles). Patching
-    the summarizer to a passthrough keeps the AskNews block intact so the
-    priority assertions test routing, not the failure path.
-    """
-    del self, question
-    await asyncio.sleep(0)
-    return research
 
 
 @pytest.mark.asyncio
@@ -49,10 +31,7 @@ async def test_run_research_priority():
 
         # Mock the provider function returned by choose_provider_with_name
         mock_asknews_func = AsyncMock(return_value="AskNews Research")
-        with (
-            patch("metaculus_bot.research.orchestrator.choose_provider_with_name") as mock_choose,
-            patch(_SUMMARIZE_ASKNEWS_PATH, _passthrough_summarize_asknews),
-        ):
+        with patch("metaculus_bot.research.orchestrator.choose_provider_with_name") as mock_choose:
             mock_choose.return_value = (mock_asknews_func, "asknews")
 
             research = await forecaster.run_research(question)

--- a/tests/test_native_search_provider.py
+++ b/tests/test_native_search_provider.py
@@ -5,24 +5,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-_SUMMARIZE_ASKNEWS_PATH = "metaculus_bot.research.orchestrator.ResearchOrchestrator._summarize_asknews"
-
-
-async def _passthrough_summarize_asknews(self, question, research):
-    """Identity stub for the AskNews summarizer.
-
-    The combine test below routes an ``"asknews"``-named provider through the
-    orchestrator, which invokes ``_summarize_asknews`` with the bogus
-    ``GeneralLlm(model="test/model")`` summarizer. That raises BadRequestError;
-    on failure the orchestrator now drops the AskNews block to empty (it no
-    longer falls back to raw articles), which would erase the provider output
-    the test asserts on. Patching the summarizer to a passthrough keeps the
-    AskNews block intact without coupling the routing test to the failure path.
-    """
-    del self, question
-    await asyncio.sleep(0)
-    return research
-
 
 def _make_q(text: str) -> MagicMock:
     """Build a minimal MetaculusQuestion-shaped mock for the new ResearchCallable
@@ -349,8 +331,7 @@ class TestParallelExecution:
         provider2 = AsyncMock(return_value="Research from provider 2")
 
         providers = [(provider1, "asknews"), (provider2, "native_search")]
-        with patch(_SUMMARIZE_ASKNEWS_PATH, _passthrough_summarize_asknews):
-            result, _ = await orch._run_providers_parallel(_make_q("Test question"), providers)
+        result, _ = await orch._run_providers_parallel(_make_q("Test question"), providers)
 
         assert "Research from provider 1" in result
         assert "Research from provider 2" in result

--- a/tests/test_provider_flag_and_logging.py
+++ b/tests/test_provider_flag_and_logging.py
@@ -14,24 +14,6 @@ _DT = datetime
 _TZ = timezone
 _ = asyncio  # used inside nested async def stubs defined in tests below
 
-_SUMMARIZE_ASKNEWS_PATH = "metaculus_bot.research.orchestrator.ResearchOrchestrator._summarize_asknews"
-
-
-async def _passthrough_summarize_asknews(self, question, research):
-    """Identity stub for the AskNews summarizer.
-
-    These tests assert on provider routing/logging, not summarizer behavior.
-    The real summarizer is the bogus ``"mock_summarizer"`` model here, which
-    raises BadRequestError when invoked; on failure the orchestrator now drops
-    the AskNews block to empty (it no longer falls back to raw articles), which
-    would erase the AskNews content these tests check. Patching the summarizer
-    to a passthrough keeps the AskNews block intact without coupling to the
-    failure path.
-    """
-    del self, question
-    await asyncio.sleep(0)
-    return research
-
 
 @pytest.fixture(autouse=True)
 def _no_sleep(monkeypatch):
@@ -69,10 +51,7 @@ async def test_research_provider_flag_and_logging(mock_os_getenv, caplog):
     )
     q = MetaculusQuestion(question_text="Test", page_url="http://example.com")
 
-    with (
-        patch("asknews_sdk.AsyncAskNewsSDK") as mock_sdk_class,
-        patch(_SUMMARIZE_ASKNEWS_PATH, _passthrough_summarize_asknews),
-    ):
+    with patch("asknews_sdk.AsyncAskNewsSDK") as mock_sdk_class:
         # Mock the SDK to return our test result
         mock_sdk = AsyncMock()
         mock_response = AsyncMock()
@@ -414,10 +393,7 @@ async def test_prediction_market_provider_integrates_with_run_providers_parallel
         captured_questions.append(question_arg)
         return await original_fetch(question_arg, **kwargs)
 
-    with (
-        patch(asknews_class_path) as mock_sdk_class,
-        patch(_SUMMARIZE_ASKNEWS_PATH, _passthrough_summarize_asknews),
-    ):
+    with patch(asknews_class_path) as mock_sdk_class:
         mock_sdk = AsyncMock()
         mock_response = AsyncMock()
         mock_response.as_dicts = []

--- a/tests/test_research_orchestrator.py
+++ b/tests/test_research_orchestrator.py
@@ -155,15 +155,13 @@ class TestAskNewsSummarization:
         invoke.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_soft_falls_back_to_empty_on_transient_summarizer_error(self, orchestrator, question):
-        """Transient LLM-provider errors (timeouts, API hiccups) drop the AskNews block to empty.
+    async def test_soft_falls_back_to_raw_on_transient_summarizer_error(self, orchestrator, question):
+        """Transient LLM-provider errors (timeouts, API hiccups) soft-fail to the raw articles.
 
         Round-2: the summarizer invoke is wrapped in the broad 30s-gated retry, which
         retries this fast asyncio.TimeoutError the full backoff schedule before it
-        surfaces and is caught by _SUMMARIZER_TRANSIENT_EXCEPTIONS. Rather than passing
-        the raw article bodies through to forecasters and the comment, we return "" so
-        the other providers carry the question. asyncio.sleep is patched so the backoffs
-        are instant.
+        surfaces and is caught by _SUMMARIZER_TRANSIENT_EXCEPTIONS → raw articles.
+        asyncio.sleep is patched so the backoffs are instant.
         """
         with (
             patch("metaculus_bot.llm_retry.asyncio.sleep", new=AsyncMock()),
@@ -176,7 +174,7 @@ class TestAskNewsSummarization:
         ):
             result = await orchestrator._summarize_asknews(question, "raw asknews articles")
 
-        assert result == ""
+        assert result == "raw asknews articles"
 
     @pytest.mark.asyncio
     async def test_non_transient_summarizer_error_propagates(self, orchestrator, question):
@@ -221,12 +219,12 @@ class TestAskNewsSummarization:
         assert invoke.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_slow_summarizer_failure_not_retried_soft_falls_to_empty(self, orchestrator, question):
-        """A summarizer failure past the 30s gate is NOT retried; it drops the AskNews block to empty.
+    async def test_slow_summarizer_failure_not_retried_soft_falls_to_raw(self, orchestrator, question):
+        """A summarizer failure past the 30s gate is NOT retried; it soft-falls to raw articles.
 
         A slow litellm.Timeout is a transient-type exception that _SUMMARIZER_TRANSIENT_
         EXCEPTIONS catches, so after the gate blocks the retry the orchestrator returns
-        "" (one invoke, no deadline-risking re-fire) rather than the raw articles.
+        the raw articles (one invoke, no deadline-risking re-fire).
         """
         import litellm.exceptions as litellm_exc
 
@@ -241,7 +239,7 @@ class TestAskNewsSummarization:
         ):
             result = await orchestrator._summarize_asknews(question, "raw asknews articles")
 
-        assert result == ""
+        assert result == "raw asknews articles"
         assert invoke.await_count == 1
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Reverts dd93567. On a summarizer failure (transient error or blank output) _summarize_asknews again returns the raw AskNews articles instead of "".

The summarizer is only a compression step; on failure the raw articles still carry the forecast signal. AskNews is the primary research provider in prod, so dropping it entirely costs the forecasters their main source on that question — worse than a noisier comment. The comment-noise case that drop-to-empty guarded against was a moot timing artifact (summarization wasn't live when the example comment was written) and only surfaces on a rare summarizer failure. Keeping the signal is the better trade.

Also reverts the test changes from dd93567: the soft-fail tests expect raw again, and the provider-routing/parallel tests no longer need the _summarize_asknews passthrough patch (the AskNews block survives on its own).